### PR TITLE
Improve tox tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,10 @@
 language: python
-python:
-  - "2.7"
-  - "2.6"
-# command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
-  - "pip install -r requirements.txt"
-  - "pip install -r requirements-test.txt"
-# command to run tests, e.g. python setup.py test
+  - pip install tox
 script:
-  coverage run --source=publisher runtests.py
-after_success:
-  coveralls
+  - tox
+env:
+  - TOXENV=django16-py27-coveralls
+  - TOXENV=django18-py27-coveralls
+  - TOXENV=django19-py27-coveralls
+  - TOXENV=flake8

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -3,7 +3,7 @@ Contributing
 ============
 
 Contributions are welcome, and they are greatly appreciated! Every
-little bit helps, and credit will always be given. 
+little bit helps, and credit will always be given.
 
 You can contribute in many ways:
 
@@ -36,7 +36,7 @@ is open to whoever wants to implement it.
 Write Documentation
 ~~~~~~~~~~~~~~~~~~~
 
-django-model-publisher could always use more documentation, whether as part of the 
+django-model-publisher could always use more documentation, whether as part of the
 official django-model-publisher docs, in docstrings, or even on the web in blog posts,
 articles, and such.
 
@@ -62,34 +62,30 @@ Ready to contribute? Here's how to set up `django-model-publisher` for local dev
 
     $ git clone git@github.com:your_name_here/django-model-publisher.git
 
-3. Install your local copy into a virtualenv. Assuming you have virtualenvwrapper installed, this is how you set up your fork for local development::
-
-    $ mkvirtualenv django-model-publisher
-    $ cd django-model-publisher/
-    $ python setup.py develop
-
-4. Create a branch for local development::
+3. Create a branch for local development::
 
     $ git checkout -b name-of-your-bugfix-or-feature
 
 Now you can make your changes locally.
 
-5. When you're done making changes, check that your changes pass flake8 and the
-tests, including testing other Python versions with tox::
+4. When you're done making changes, check that your changes pass flake8 and the
+tests with tox::
 
-    $ flake8 publisher tests
-    $ python setup.py test
-    $ tox
+    $ tox -e flake8,django18-py27  # Specific envs
+    $ tox  # All envs
 
-To get flake8 and tox, just pip install them into your virtualenv. 
-
-6. Commit your changes and push your branch to GitHub::
+5. Commit your changes and push your branch to GitHub::
 
     $ git add .
     $ git commit -m "Your detailed description of your changes."
     $ git push origin name-of-your-bugfix-or-feature
 
-7. Submit a pull request through the GitHub website.
+6. Submit a pull request through the GitHub website.
+
+7. If you want to test your branch as a dependency of another project, install
+it into your project's virtualenv:
+
+    (venv)$ pip install -e path/to/django-model-publisher
 
 Pull Request Guidelines
 -----------------------
@@ -100,7 +96,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 2.6, 2.7, and 3.3, and for PyPy. Check 
+3. The pull request should work for Python 2.6, 2.7, and 3.3, and for PyPy. Check
    https://travis-ci.org/jp74/django-model-publisher/pull_requests
    and make sure that the tests pass for all supported Python versions.
 
@@ -109,4 +105,4 @@ Tips
 
 To run a subset of tests::
 
-    $ python -m unittest tests.test_publisher
+    $ tox -e django18-py27 -- publisher.tests.tests:TestCase.test_method

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,9 +1,0 @@
-coverage==3.7.1
-coveralls==0.4.2
-mock==1.0.1
-nose==1.3.3
-django-nose==1.2
-flake8==2.1.0
-tox==1.7.1
-
-# Additional test requirements go here

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-django>=1.4.3,<=1.6.99
-wheel==0.23.0
-# Additional requirements go here
-django-model-utils==2.0.3

--- a/runtests.py
+++ b/runtests.py
@@ -1,52 +1,41 @@
 import sys
 
+from django.conf import settings
+import django
+
+settings.configure(
+    DEBUG=True,
+    USE_TZ=True,
+    DATABASES={
+        'default': {
+            'ENGINE': 'django.db.backends.sqlite3',
+        }
+    },
+    ROOT_URLCONF='publisher.urls',
+    INSTALLED_APPS=[
+        'django.contrib.auth',
+        'django.contrib.contenttypes',
+        'django.contrib.sites',
+        'publisher',
+    ],
+    SITE_ID=1,
+    NOSE_ARGS=['-s'],
+)
+
 try:
-    from django.conf import settings
-
-    settings.configure(
-        DEBUG=True,
-        USE_TZ=True,
-        DATABASES={
-            'default': {
-                'ENGINE': 'django.db.backends.sqlite3',
-            }
-        },
-        ROOT_URLCONF='publisher.urls',
-        INSTALLED_APPS=[
-            'django.contrib.auth',
-            'django.contrib.contenttypes',
-            'django.contrib.sites',
-            'publisher',
-        ],
-        SITE_ID=1,
-        NOSE_ARGS=['-s'],
-    )
-
-    try:
-        import django
-        setup = django.setup
-    except AttributeError:
-        pass
-    else:
-        setup()
-
-    from django_nose import NoseTestSuiteRunner
-except ImportError:
-    raise ImportError('To fix this error, run: pip install -r requirements-test.txt')
+    django.setup()
+except AttributeError:
+    pass
 
 
 def run_tests(*test_args):
+    from django_nose import NoseTestSuiteRunner
     if not test_args:
         test_args = ['publisher.tests.tests']
-
-    # Run tests
     test_runner = NoseTestSuiteRunner(verbosity=1)
-
     failures = test_runner.run_tests(test_args)
-
     if failures:
         sys.exit(failures)
-
 
 if __name__ == '__main__':
     run_tests(*sys.argv[1:])

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'Django>=1.4.3',
-        'django-model-utils>=2.0.3',
+        'django-model-utils>=2.0.3,<2.4',
     ],
     license="BSD",
     zip_safe=False,

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
     django18-py{27,32,33,34,35}
     django19-py{27,34,35}
     flake8
+    pylint
 skipsdist = True
 
 [testenv]
@@ -26,3 +27,7 @@ usedevelop = True
 [testenv:flake8]
 commands = flake8 publisher
 deps = flake8
+
+[testenv:pylint]
+commands = pylint publisher
+deps = pylint

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
     django18-py{27,32,33,34,35}
     django19-py{27,34,35}
     flake8
+skipsdist = True
 
 [testenv]
 commands =
@@ -20,6 +21,7 @@ deps =
     django19: django>=1.9,<1.10
     mock
 passenv = TRAVIS TRAVIS_BRANCH TRAVIS_JOB_ID
+usedevelop = True
 
 [testenv:flake8]
 commands = flake8 publisher

--- a/tox.ini
+++ b/tox.ini
@@ -10,17 +10,18 @@ skipsdist = True
 
 [testenv]
 commands =
-    coverage run --source=publisher runtests.py {posargs}
-    coveralls: coveralls
+    cov: coverage run --source=publisher runtests.py {posargs}
+    cov: coveralls
+    nocov: python runtests.py {posargs}
 deps =
-    coverage
-    coveralls: coveralls
     django-nose
+    mock
+    cov: coverage
+    cov: coveralls
     django16: django>=1.6,<1.7
     django17: django>=1.7,<1.8
     django18: django>=1.8,<1.9
     django19: django>=1.9,<1.10
-    mock
 passenv = TRAVIS TRAVIS_BRANCH TRAVIS_JOB_ID
 usedevelop = True
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,26 @@
 [tox]
-envlist = py26, py27, py33
+envlist =
+    django16-py{26,27,32,33}
+    django17-py{27,32,33,34}
+    django18-py{27,32,33,34,35}
+    django19-py{27,34,35}
+    flake8
 
 [testenv]
-setenv =
-    PYTHONPATH = {toxinidir}:{toxinidir}/publisher
-commands = python runtests.py
+commands =
+    coverage run --source=publisher runtests.py {posargs}
+    coveralls: coveralls
 deps =
-    -r{toxinidir}/requirements-test.txt
+    coverage
+    coveralls: coveralls
+    django-nose
+    django16: django>=1.6,<1.7
+    django17: django>=1.7,<1.8
+    django18: django>=1.8,<1.9
+    django19: django>=1.9,<1.10
+    mock
+passenv = TRAVIS TRAVIS_BRANCH TRAVIS_JOB_ID
+
+[testenv:flake8]
+commands = flake8 publisher
+deps = flake8


### PR DESCRIPTION
Testing should be as easy as:

```
$ git clone ... foo
$ cd foo
$ pip install tox
$ tox
```

This should test all supported versions of Django and Python, run flake8 over the code, generate coverage data and run coveralls.

Changes in this PR include:
- Test supported versions of Python against Django 1.6 through 1.9
- Don't bother catching import errors in `runtests.py`, which is executed inside
  the tox env. All dependencies should be installed into the env by tox.
- Code style in `runtests.py`. Move imports to top of `runtests.py`, where
  possible. PEP8 white space and consistent line endings.
- Don't manipulate `PYTHONPATH` inside the tox env. The current working
  directory (usually the same as `toxinidir`) is already added to `PYTHONPATH`
  when python is executed, and modules inside the `publisher` package should not
  also be available via direct imports. Ideally, the working copy (current
  working directory) should not be in the python path to ensure tox tests the
  built package it installs, instead of the working copy.
- Remove `tox` from test requirements. We don't need `tox` to be installed
  into the tox env. We need it to be installed at system level (or in a
  virtualenv), so we can run it. Since it is the only dependency, we may as well
  just install it directly.
- Move test dependencies into `tox.ini`, because some are required only for
  specific test envs, e.g. `flake8`.
- Remove absolute version specs from test dependencies. We might as well keep
  testing tools up-to-date.
- Remove nested `nose` dependency. We don't use it directly, `django-nose` uses
  it and so it will be installed as a dependency of `django-nose`.
- Add `flake8` test env to `tox.ini`.
- Remove redundant setuptools tests from contributing docs. Testing with tox is
  enough.
- Run coverage and coveralls from inside tox.
- Test with tox on Travis CI. Test all versions of Django against Python 2.7
- Only run coveralls on Travis CI.
- Remove redundant `requirements.txt` file. Dependencies are specified in
  `setup.py`.
- Pass positional args to test runner inside tox, to run a subset of tests.
- Update contributing docs. Remove section about installing working copy into a
  virtualenv. This is not necessary. Instead, add a section on installing as a
  dependency of another project.
