### PR TITLE
Use `as_manager()` instead of `PassThroughManagerMixin`. Require Djan…

### DIFF
--- a/publisher/managers.py
+++ b/publisher/managers.py
@@ -1,8 +1,6 @@
 from django.db import models
 from django.db.models.query import QuerySet
 
-from model_utils.managers import PassThroughManagerMixin
-
 from .signals import publisher_pre_delete
 from .middleware import get_draft_status
 
@@ -23,7 +21,7 @@ class PublisherQuerySet(QuerySet):
         return self.published()
 
 
-class PublisherManager(PassThroughManagerMixin, models.Manager):
+class PublisherManager(models.Manager):
 
     def contribute_to_class(self, model, name):
         super(PublisherManager, self).contribute_to_class(model, name)

--- a/publisher/models.py
+++ b/publisher/models.py
@@ -270,7 +270,7 @@ class PublisherModelBase(models.Model):
 
 class PublisherModel(PublisherModelBase):
     objects = models.Manager()
-    publisher_manager = PublisherManager.for_queryset_class(PublisherQuerySet)()
+    publisher_manager = PublisherQuerySet.as_manager()
 
     class Meta:
         abstract = True

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,7 @@ setup(
     ],
     include_package_data=True,
     install_requires=[
-        'Django>=1.4.3',
-        'django-model-utils>=2.0.3',
+        'Django>=1.7',
     ],
     license="BSD",
     zip_safe=False,


### PR DESCRIPTION
…go >=1.7

The former was added to Django in 1.7 and the latter was removed from
`django-model-utils` in 2.4.

Looks like tests don't pass on 1.7, but we've been using `django-model-publisher` in a 1.7 project. #25 should make it easier to spot and fix issues with 1.7-1.9.
