### PR TITLE
Replace deprecated url patterns

### DIFF
--- a/publisher/admin.py
+++ b/publisher/admin.py
@@ -3,7 +3,7 @@ import json
 import django
 from django.contrib.admin import ModelAdmin, SimpleListFilter
 from django.contrib import messages
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.core.exceptions import PermissionDenied
 from django.core.urlresolvers import reverse
 from django.http import Http404, HttpResponseRedirect, HttpResponse
@@ -171,15 +171,12 @@ class PublisherAdmin(ModelAdmin):
         publish_name = '%spublish' % (self.url_name_prefix, )
         unpublish_name = '%sunpublish' % (self.url_name_prefix, )
         revert_name = '%srevert' % (self.url_name_prefix, )
-        
-        publish_urls = patterns('',
-            url(r'^(?P<object_id>\d+)/publish/$',
-                self.publish_view, name=publish_name),
-            url(r'^(?P<object_id>\d+)/unpublish/$',
-                self.unpublish_view, name=unpublish_name),
-            url(r'^(?P<object_id>\d+)/revert/$',
-                self.revert_view, name=revert_name),
-        )
+
+        publish_urls = [
+            url(r'^(?P<object_id>\d+)/publish/$', self.publish_view, name=publish_name),
+            url(r'^(?P<object_id>\d+)/unpublish/$', self.unpublish_view, name=unpublish_name),
+            url(r'^(?P<object_id>\d+)/revert/$', self.revert_view, name=revert_name),
+        ]
 
         return publish_urls + urls
 


### PR DESCRIPTION
Fix publish_urls to be Django 1.8 and greater compatible using a list… instead of the deprecated django url patterns().