### PR TITLE
Remove deprecated use of url from future in templates

### DIFF
--- a/publisher/templates/publisher/change_form.html
+++ b/publisher/templates/publisher/change_form.html
@@ -1,6 +1,6 @@
 {% extends "admin/change_form.html" %}
 {% load i18n admin_static admin_modify admin_urls %}
-{% load url from future %}
+
 {% block object-tools %}
     {{ block.super }}
 	{% if change %}{% if not is_popup %}

--- a/publisher/templates/publisher/hvad/change_form.html
+++ b/publisher/templates/publisher/hvad/change_form.html
@@ -1,6 +1,5 @@
 {% extends base_template %}
 {% load i18n admin_static admin_modify admin_urls %}
-{% load url from future %}
 
 {% block extrahead %}
 {{ block.super }}

--- a/publisher/templates/publisher/parler/change_form.html
+++ b/publisher/templates/publisher/parler/change_form.html
@@ -1,6 +1,6 @@
 {% extends "admin/parler/change_form.html" %}
 {% load i18n admin_static admin_modify admin_urls %}
-{% load url from future %}
+
 {% block object-tools-items %}
     {% if change and not is_popup %}
 		{% if has_publish_permission %}


### PR DESCRIPTION
As stated in the [docs](https://docs.djangoproject.com/en/1.9/releases/1.7/#loading-ssi-and-url-template-tags-from-future-library), `load url from future` is deprecated and not needed anymore.